### PR TITLE
Fix "'::strlen' has not been declared" in assimp

### DIFF
--- a/external/assimp-3.0.1270/include/assimp/types.h
+++ b/external/assimp-3.0.1270/include/assimp/types.h
@@ -65,6 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __cplusplus
 #include <new>		// for std::nothrow_t
 #include <string>	// for aiString::Set(const std::string&)
+#include <cstring>	// to fix the compiler error "error: '::strlen' has not been declared"
 
 namespace Assimp	{
 	//! @cond never


### PR DESCRIPTION
Trying to compile it on MSYS2, you will get the error:

```
error: '::strlen' has not been declared
```

Including the additional header **cstring** in **types.h** file fixes this problem. In the long run, it might be best to upgrade the assimp library to version 3.1.1 (released June 2014).
