### PR TITLE
error in loadBMP_custom

### DIFF
--- a/common/texture.cpp
+++ b/common/texture.cpp
@@ -51,6 +51,8 @@ GLuint loadBMP_custom(const char * imagepath){
 	if (imageSize==0)    imageSize=width*height*3; // 3 : one byte for each Red, Green and Blue component
 	if (dataPos==0)      dataPos=54; // The BMP header is done that way
 
+	fseek(file, dataPos, SEEK_SET);
+
 	// Create a buffer
 	data = new unsigned char [imageSize];
 


### PR DESCRIPTION
If dataPos is longer then 54, the data read will include parts of the BMP header, so the file pointer needs 
to be updated.