### PR TITLE
Colors in fragment shader example work better as vec4 instead of vec3

### DIFF
--- a/tutorial08_basic_shading/StandardShading.fragmentshader
+++ b/tutorial08_basic_shading/StandardShading.fragmentshader
@@ -8,7 +8,7 @@ in vec3 EyeDirection_cameraspace;
 in vec3 LightDirection_cameraspace;
 
 // Ouput data
-out vec3 color;
+out vec4 color;
 
 // Values that stay constant for the whole mesh.
 uniform sampler2D myTextureSampler;
@@ -19,13 +19,13 @@ void main(){
 
 	// Light emission properties
 	// You probably want to put them as uniforms
-	vec3 LightColor = vec3(1,1,1);
+	vec4 LightColor = vec4(1,1,1,1);
 	float LightPower = 50.0f;
 	
 	// Material properties
-	vec3 MaterialDiffuseColor = texture( myTextureSampler, UV ).rgb;
-	vec3 MaterialAmbientColor = vec3(0.1,0.1,0.1) * MaterialDiffuseColor;
-	vec3 MaterialSpecularColor = vec3(0.3,0.3,0.3);
+	vec4 MaterialDiffuseColor = texture( myTextureSampler, UV ).rgba;
+	vec4 MaterialAmbientColor = vec4(0.1,0.1,0.1,1.0) * MaterialDiffuseColor;
+	vec4 MaterialSpecularColor = vec4(0.3,0.3,0.3,1.0);
 
 	// Distance to the light
 	float distance = length( LightPosition_worldspace - Position_worldspace );


### PR DESCRIPTION
Just trying to fix a typo that had me stuck for a while.