### PR TITLE
the camera was terrible on Linux.  Fixed that

### DIFF
--- a/common/controls.cpp
+++ b/common/controls.cpp
@@ -46,26 +46,29 @@ void computeMatricesFromInputs(){
 	// Get mouse position
 	double xpos, ypos;
 
-        // for some reason, on linux, the camera ends up in a random location
-        // because of glfwGetCursorPos glfwSetCursorPos, whereas on Windows
-        // it works just fine.
-        // To make the camera work consistently across platforms, set
-        // the cursor location on first rendering, and only compute the
-        // offset on subsequent renderings.
-        static bool firstPass = true;
-        if(!firstPass){
-          glfwGetCursorPos(window, &xpos, &ypos);
-        }
+    // for some reason, on linux, the camera ends up in a random location
+    // because of glfwGetCursorPos glfwSetCursorPos, whereas on Windows
+    // it works just fine.
+    // To make the camera work consistently across platforms, set
+    // the cursor location on first rendering, and only compute the
+    // offset on subsequent renderings.
+    static bool firstPass = true;
+    if(!firstPass){
+      glfwGetCursorPos(window, &xpos, &ypos);
+    }
 
 	// Reset mouse position for next frame
 	glfwSetCursorPos(window, 1024/2, 768/2);
 
-        // Compute new orientation after the first frame
-        if(!firstPass){
-          // Compute new orientation
-          horizontalAngle += mouseSpeed * float(1024/2 - xpos );
-          verticalAngle   += mouseSpeed * float( 768/2 - ypos );
-        }
+    // Compute new orientation after the first frame
+    if(!firstPass){
+      // Compute new orientation
+      horizontalAngle += mouseSpeed * float(1024/2 - xpos );
+      verticalAngle   += mouseSpeed * float( 768/2 - ypos );
+     }
+	else {
+	  firstPass = false;
+     }
 
 	// Direction : Spherical coordinates to Cartesian coordinates conversion
 	glm::vec3 direction(

--- a/common/controls.cpp
+++ b/common/controls.cpp
@@ -21,7 +21,7 @@ glm::mat4 getProjectionMatrix(){
 
 
 // Initial position : on +Z
-glm::vec3 position = glm::vec3( 0, 0, 5 ); 
+glm::vec3 position = glm::vec3( 0, 0, 5 );
 // Initial horizontal angle : toward -Z
 float horizontalAngle = 3.14f;
 // Initial vertical angle : none
@@ -45,29 +45,42 @@ void computeMatricesFromInputs(){
 
 	// Get mouse position
 	double xpos, ypos;
-	glfwGetCursorPos(window, &xpos, &ypos);
+
+        // for some reason, on linux, the camera ends up in a random location
+        // because of glfwGetCursorPos glfwSetCursorPos, whereas on Windows
+        // it works just fine.
+        // To make the camera work consistently across platforms, set
+        // the cursor location on first rendering, and only compute the
+        // offset on subsequent renderings.
+        static bool firstPass = true;
+        if(!firstPass){
+          glfwGetCursorPos(window, &xpos, &ypos);
+        }
 
 	// Reset mouse position for next frame
 	glfwSetCursorPos(window, 1024/2, 768/2);
 
-	// Compute new orientation
-	horizontalAngle += mouseSpeed * float(1024/2 - xpos );
-	verticalAngle   += mouseSpeed * float( 768/2 - ypos );
+        // Compute new orientation after the first frame
+        if(!firstPass){
+          // Compute new orientation
+          horizontalAngle += mouseSpeed * float(1024/2 - xpos );
+          verticalAngle   += mouseSpeed * float( 768/2 - ypos );
+        }
 
 	// Direction : Spherical coordinates to Cartesian coordinates conversion
 	glm::vec3 direction(
-		cos(verticalAngle) * sin(horizontalAngle), 
+		cos(verticalAngle) * sin(horizontalAngle),
 		sin(verticalAngle),
 		cos(verticalAngle) * cos(horizontalAngle)
 	);
-	
+
 	// Right vector
 	glm::vec3 right = glm::vec3(
-		sin(horizontalAngle - 3.14f/2.0f), 
+		sin(horizontalAngle - 3.14f/2.0f),
 		0,
 		cos(horizontalAngle - 3.14f/2.0f)
 	);
-	
+
 	// Up vector
 	glm::vec3 up = glm::cross( right, direction );
 


### PR DESCRIPTION
Perhaps this is a GLFW implementation thing, but on Linux, the camera ended up in a random location for all demos; to the point that this demo code was unusable.
This commit fixes that, and I have verified that on Windows it still works for at least demo 08, and I am confident that this fix makes no changes on anything other than the first frame.
