### PR TITLE
Fix errors in russian translation for tutorial 1

### DIFF
--- a/ru/beginners-tutorials/tutorial-1-opening-a-window/index.markdown
+++ b/ru/beginners-tutorials/tutorial-1-opening-a-window/index.markdown
@@ -79,7 +79,9 @@ order: 10
 * libgl1-mesa-dev
 * libglu1-mesa-dev
 * libxrandr-dev
-* libext-dev
+* libxext-dev
+* libxcursor-dev
+* libxinerama-dev
 
 Используйте sudo apt-get install ***** или su && yum install ******.
 * [Скачайте исходный код](/?page_id=200) и распакуйте его, к примеру в ~/Projects/OpenGLTutorials/


### PR DESCRIPTION
Fix typo in libxext-dev library name
Add two libraries required to build examples:
* libxcursor-dev
* libxinerama-dev