### PR TITLE
Use `memcpy` instead of `*(int)*&`

### DIFF
--- a/beginners-tutorials/tutorial-5-a-textured-cube/index.markdown
+++ b/beginners-tutorials/tutorial-5-a-textured-cube/index.markdown
@@ -95,11 +95,14 @@ if ( header[0]!='B' || header[1]!='M' ){
 Now we can read the size of the image, the location of the data in the file, etc :
 
 ``` cpp
+// add to standard headers
+#include <string.h>
+
 // Read ints from the byte array
-dataPos    = *(int*)&(header[0x0A]);
-imageSize  = *(int*)&(header[0x22]);
-width      = *(int*)&(header[0x12]);
-height     = *(int*)&(header[0x16]);
+memcpy(&dataPos, header + 0xA, sizeof dataPos);
+memcpy(&imageSize, header + 0x22, sizeof imageSize);
+memcpy(&width, header + 0x12, sizeof width);
+memcpy(&height, header + 0x16, sizeof height);
 ```
 
 We have to make up some info if it's missing :


### PR DESCRIPTION
The issues with  `*(int)*&` are that
- It is quite confusing (especially for C++ beginners)
- In this case, it is a strict aliasing violation

A solution can therefore be to replace it with `memcpy`

I am only making a single PR, but this change (if approved) probably needs to be made in other locations.

_This PR comes after a question I asked on [StackOverflow](https://stackoverflow.com/questions/68699806/strange-c-type-casting)_