### PR TITLE
modified CMakeLists.txt from the external folder 

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -41,9 +41,7 @@ set(GLEW_SOURCE
 	glew-1.13.0/src/glew.c
 )
 
-set(GLEW_HEADERS
-)
-
+set(GLEW_HEADERS glew-1.13.0/include/GL/glew.h)
 
 add_library( GLEW_1130 STATIC
 	${GLEW_SOURCE}


### PR DESCRIPTION
I don't know if you didn't include the GLEW_HEADERS to the build intentionally, though it was working perfectly without any issue. I decided to add it just for clarity