### PR TITLE
resolve missing 'binary_function' template definition

### DIFF
--- a/external/AntTweakBar-1.16/src/TwMgr.cpp
+++ b/external/AntTweakBar-1.16/src/TwMgr.cpp
@@ -7,6 +7,7 @@
 //
 //  ---------------------------------------------------------------------------
 
+#include <functional>
 
 #include "TwPrecomp.h"
 #include <AntTweakBar.h>


### PR DESCRIPTION
- failed to build external lib ANTTWEAKBAR v1.16 because of missing definition for 'binary_function'
- including the 'functional' header resolved the error

https://github.com/opengl-tutorials/ogl/blob/316cccc5f76f47f09c16089d98be284b689e057d/external/AntTweakBar-1.16/src/TwMgr.cpp#L5754